### PR TITLE
support sub-directory in the image folder

### DIFF
--- a/templates/display_image.html
+++ b/templates/display_image.html
@@ -33,7 +33,7 @@ block header %} {% endblock %} {% block content %}
 </script>
 <br />
 
-<h2 class="text-3xl">50 Similar Images</h2>
+<h2 class="text-3xl">10 Similar Images</h2>
 
 <hr />
 <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block header %}
-   <h1 class="text-3xl">50 random images</h1>
+   <h1 class="text-3xl">10 random images</h1>
 {% endblock %}
 
 


### PR DESCRIPTION
I have the main branch using a simple photo folder: it have 13 .jpeg files in ./ and 13 .jpeg in ./2015_12 folder:
.
├── 2015_12
│   ├── 20151201_IMG_4403.JPG
│...
│   └── 20151231_IMG_4435.JPG
├── DSC01938.JPG
...
├── DSC01943.JPG;
the start_web.py return 404 for all files in ./2015_12 folder as it direct join image directory and filename, omit the relative path.

get_file_path_from_db(filename) use input filename and compare with info in the database and return absolute full file path.

WARNING: This may slow down the process when database is rather large!
